### PR TITLE
Better Linearizable Batching + Asynch Requests Flag 

### DIFF
--- a/kvs/client/main.go
+++ b/kvs/client/main.go
@@ -25,32 +25,6 @@ func Dial(addr string) *Client {
 	return &Client{rpcClient}
 }
 
-// Send a batch of keys to retrieve
-func (client *Client) BatchGet(keys []string) []string {
-	request := kvs.BatchGetRequest{
-		Keys: keys,
-	}
-	response := kvs.BatchGetResponse{}
-	err := client.rpcClient.Call("KVService.BatchGet", &request, &response)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return response.Values
-}
-
-// Send a batch of key-value pairs to modify
-func (client *Client) BatchPut(putData map[string]string) {
-	request := kvs.BatchPutRequest{
-		Data: putData,
-	}
-	//response := kvs.BatchPutResponse{}
-	err := client.rpcClient.Call("KVService.BatchPut", &request, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
 func (client *Client) SendBatch(putData map[string]string) []string {
 	request := kvs.Batch_Request{
 		Data: putData,

--- a/kvs/client/main.go
+++ b/kvs/client/main.go
@@ -77,7 +77,7 @@ func runClient(id int, addr string, done *atomic.Bool, workload *kvs.Workload, r
 		}
 
 		if asynch {
-			var calls []*rpc.Call
+			calls := make([]*rpc.Call, 0, batchSize)
 			if len(batchData) > 0 {
 				calls = append(calls, client.Send_Asynch_Batch(batchData))
 			}

--- a/kvs/proto.go
+++ b/kvs/proto.go
@@ -1,9 +1,15 @@
 package kvs
 
 type Batch_Request struct {
-	Data map[string]string
+	Data []BatchOperation
 }
 
 type Batch_Response struct {
 	Values []string
+}
+
+type BatchOperation struct {
+	Key    string
+	Value  string
+	IsRead bool
 }

--- a/kvs/proto.go
+++ b/kvs/proto.go
@@ -1,8 +1,18 @@
 package kvs
 
+type Batch_Request struct {
+	Data map[string]string
+}
+
+type Batch_Response struct {
+	Values []string
+}
+
 type BatchPutRequest struct {
 	Data map[string]string
 }
+
+
 
 type BatchPutResponse struct {
 }

--- a/kvs/proto.go
+++ b/kvs/proto.go
@@ -7,21 +7,3 @@ type Batch_Request struct {
 type Batch_Response struct {
 	Values []string
 }
-
-type BatchPutRequest struct {
-	Data map[string]string
-}
-
-
-
-type BatchPutResponse struct {
-}
-
-type BatchGetRequest struct {
-	Keys []string
-}
-
-type BatchGetResponse struct {
-	Keys   []string
-	Values []string
-}

--- a/kvs/server/main.go
+++ b/kvs/server/main.go
@@ -137,6 +137,28 @@ func (kv *KVService) BatchPut(request *kvs.BatchPutRequest, response *kvs.BatchP
 	return nil
 }
 
+func (kv *KVService) Process_Batch(request *kvs.Batch_Request, response *kvs.Batch_Response) error {
+	kv.stats.puts += uint64(len(request.Data))
+
+	response.Values = make([]string, len(request.Data))
+
+	var i = 0
+	for key, value := range request.Data {
+		if value == "" {
+
+			if value, found := kv.Get(key); found {
+				response.Values[i] = value
+			}
+
+		} else {
+			kv.Put(key, value, time.Duration(100 * float64(time.Millisecond)))
+		}
+		i++
+	}
+
+	return nil
+}
+
 func (kv *KVService) printStats() {
 	kv.Lock()
 	stats := kv.stats


### PR DESCRIPTION
This PR does the following:

1. Improves Batching.
- Instead of sending two separate batches of "Get" and "Put" RPC calls, send a single batch.  
- Client has a variable "batchSize" which controls how many requests are put in a batch. 
- The server was also adjusted to process a single batch. 
- proto file was changed to add "BatchOperation" struct to support agnostic requests.
- IMO, such batching is arguably linearizable. 

3. Asynch RPC
- Adds a flag "asynch", which is false by default. If true, will send RPC calls asynchronously. 
- Eventually, asynch calls are waited upon and conceptually are similar to channels.   

IMPORTANT: I ask you to please try it on your personal machine or cluster. On a cluster, you should see the performance of 600k ops with asynch=false, and 3M ops with asynch=true 