### PR TITLE
At least once

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Useful commands
+
+ssh node[num] 
+exit to leave
+
+ip addr
+
+./run-cluster.sh 1 1 "" "-asynch"
+
+nproc - number of cores
+
+
+
+# notes
+runcluster script autmaitcally if give num servers will make the remaining one's clients. also as client arg it will give all the server ip:ports as hosts which ends up in hostlist.

--- a/kvs/client/main.go
+++ b/kvs/client/main.go
@@ -62,7 +62,7 @@ func hashKey(key string) uint32 {
 	return h.Sum32()
 }
 
-func runConnection(wg sync.WaitGroup, hosts []string, done *atomic.Bool, workload *kvs.Workload, totalOpsCompleted *uint64, asynch bool) {
+func runConnection(wg *sync.WaitGroup, hosts []string, done *atomic.Bool, workload *kvs.Workload, totalOpsCompleted *uint64, asynch bool) {
 	defer wg.Done()
 
 	// Dial all hosts
@@ -129,7 +129,7 @@ func runClient(id int, hosts []string, done *atomic.Bool, workload *kvs.Workload
 		wg.Add(1)
 	}
 	for connId := 0; connId < numConnections; connId++ {
-		go runConnection(wg, hosts, done, workload, &totalOpsCompleted, asynch)
+		go runConnection(&wg, hosts, done, workload, &totalOpsCompleted, asynch)
 	}
 
 	fmt.Println("waiting for connections to finish")

--- a/kvs/client/main.go
+++ b/kvs/client/main.go
@@ -75,7 +75,7 @@ func runClient(id int, hosts []string, done *atomic.Bool, workload *kvs.Workload
 			}
 
 			value := strings.Repeat("x", 128)
-			const batchSize = 1024
+			const batchSize = 5000 //1024
 			opsCompleted := uint64(0)
 
 			for !done.Load() {

--- a/kvs/proto.go
+++ b/kvs/proto.go
@@ -1,7 +1,8 @@
 package kvs
 
 type Batch_Request struct {
-	Data []BatchOperation
+	RequestID int64
+	Data      []BatchOperation
 }
 
 type Batch_Response struct {

--- a/run-cluster.sh
+++ b/run-cluster.sh
@@ -19,7 +19,7 @@ usage() {
     echo "  $0 2                                  # 2 servers, rest as clients"
     echo "  $0 2 3                               # 2 servers, 3 clients"
     echo "  $0 2 3 \"-port 8080\""
-    echo "  $0 2 3 \"-port 8080\" \"-threads 4 -duration 30s\""
+    echo " $0 2 3 \"-port 8080\" \"-workload YCSB-A -secs 30\""
     exit 1
 }
 
@@ -43,17 +43,11 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LOG_ROOT="${ROOT}/logs"
 
 function cluster_size() {
-    geni-get -a | \
-        grep -Po '<host name=\\".*?\"' | \
-        sed 's/<host name=\\"\(.*\)\\"/\1/' | \
-        sort | \
-        uniq | \
-        wc -l
+    /usr/local/etc/emulab/tmcc hostnames | wc -l
 }
 
 # Get available node count first to determine defaults
-AVAILABLE_COUNT=4
-# $(cluster_size)
+AVAILABLE_COUNT=$(cluster_size)
 
 # Parse arguments with defaults based on available nodes
 if [ "$#" -eq 0 ]; then

--- a/run-cluster.sh
+++ b/run-cluster.sh
@@ -52,7 +52,8 @@ function cluster_size() {
 }
 
 # Get available node count first to determine defaults
-AVAILABLE_COUNT=$(cluster_size)
+AVAILABLE_COUNT=4
+# $(cluster_size)
 
 # Parse arguments with defaults based on available nodes
 if [ "$#" -eq 0 ]; then


### PR DESCRIPTION
Pretty straightforward stuff. Minimal impact on performance.

```
cayden@node0:/mnt/nfs/cayden/cs6450-labs$ ./run-cluster.sh 2 2 "-numshards 1000" "-connections 70 -asynch"
Using 4 of 4 available nodes (node0 to node3)
Server nodes: node0 node1
Client nodes: node2 node3
Server args: -numshards 1000
Client args: -connections 70 -asynch

Logs will be in /mnt/nfs/cayden/cs6450-labs/logs/20250831-214713
Initial cluster cleanup...
Cleaning up processes on all nodes...
Cleaning up processes on node0...
Cleaning up processes on node1...
Cleaning up processes on node2...
Cleaning up processes on node3...
Cleanup complete.

Building the project...
Building KVS server...
go build -v  -o bin/kvsserver ./kvs/server

Starting server on node0...
Starting server on node1...
Starting client on node2...
Starting client on node3...
Waiting for clients to finish...
All clients finished.
Run complete. Logs in /mnt/nfs/cayden/cs6450-labs/logs/20250831-214713

node0 median 8112804 op/s
node1 median 8987585 op/s

total 17100389 op/s

Cleaning up processes on all nodes...
Cleaning up processes on node0...
Cleaning up processes on node1...
Cleaning up processes on node2...
Cleaning up processes on node3...
Cleanup complete.
```