### PR TITLE
Quick fix after merges

### DIFF
--- a/kvs/client/main.go
+++ b/kvs/client/main.go
@@ -79,8 +79,6 @@ func (client *Client) Send_Asynch_Batch(putData []kvs.BatchOperation) *rpc.Call 
 	}
 	response := kvs.Batch_Response{}
 
-	call := client.rpcClient.Go("KVService.Process_Batch", &request, &response, nil)
-
 	// Create a synthetic Call to return immediately
 	resultCall := &rpc.Call{
 		Done: make(chan *rpc.Call, 1),
@@ -116,12 +114,6 @@ func (client *Client) Send_Asynch_Batch(putData []kvs.BatchOperation) *rpc.Call 
 	}()
 
 	return resultCall
-}
-
-func hashKey(key string) uint32 {
-	h := fnv.New32a()
-	h.Write([]byte(key))
-	return h.Sum32()
 }
 
 func hashKey(key string) uint32 {


### PR DESCRIPTION
After merging the last 2 branches, some redundant code was left over. The project would not compile without these changes. 

 `hashKey` was declared twice, and there was a redundant `client.rpcClient.Go` request.