### PR TITLE
Brendon's 2PL Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ip addr
 
 nproc - number of cores
 
-
+./run-cluster.sh 1 1 "" "-connections 10 -payments true"
 
 # notes
 runcluster script autmaitcally if give num servers will make the remaining one's clients. also as client arg it will give all the server ip:ports as hosts which ends up in hostlist.

--- a/kvs/proto.go
+++ b/kvs/proto.go
@@ -16,4 +16,6 @@ type Operation struct {
 	Key    string
 	Value  string
 	IsRead bool
+	// default false
+	ForUpdate bool
 }

--- a/kvs/proto.go
+++ b/kvs/proto.go
@@ -8,7 +8,8 @@ type Operation_Request struct {
 }
 
 type Operation_Response struct {
-	Value string
+	Value   string
+	Success bool
 }
 
 type Operation struct {

--- a/kvs/server/main.go
+++ b/kvs/server/main.go
@@ -360,7 +360,7 @@ func (kv *KVService) printStats() {
 	diff := stats.Sub(&prevStats)
 	deltaS := now.Sub(lastPrint).Seconds()
 
-
+	// NOTE: commits and aborts will print on all servers
 	fmt.Printf("get/s %0.2f\nput/s %0.2f\nops/s %0.2f\ncommits/s %0.2f\naborts/s %0.2f\n\n",
 		float64(diff.gets)/deltaS,
 		float64(diff.puts)/deltaS,


### PR DESCRIPTION
To my current understanding, Brendon's changes have the following logic:

- One transaction operation is one message to one server
- When necessary, grab locks like a typical 2PL implementation (escalate from RLocks to WLocks with an added dependency)
- Each op message responds with either a deadlock error (implicit "vote no" for 2PC) or a valid result (implicit "vote yes")
- "Prepare" messages as part of 2PC are not incorporated
- Once each operation has been processed, each participant is sent a commit or abort message, according to typical 2PC
- Participants commit or abort accordingly

Note that this isn't the typical 2 phase commit discussed in class, but is a solid approach to 2 phase locking. Personally, I feel there may be some edge cases we're missing by not including a "prepare" message, but it may be irrelevant when not considering server failures.

@ArtyNar and @caydenlund, we would love your input ASAP.